### PR TITLE
Fix race condition during server shutdown

### DIFF
--- a/server.go
+++ b/server.go
@@ -106,9 +106,9 @@ func (s *Server) Start(ctx context.Context) (string, error) {
 }
 
 // Stop stops the server
-func (s *Server) Stop() error {
+func (s *Server) Stop(ctx context.Context) error {
 	if s.httpServer != nil {
-		return s.httpServer.Shutdown(context.Background())
+		return s.httpServer.Shutdown(ctx)
 	}
 	return nil
 }

--- a/server_test.go
+++ b/server_test.go
@@ -2,6 +2,7 @@ package mockllm_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -73,7 +74,7 @@ func TestSimpleOpenAIMock(t *testing.T) {
 	server := mockllm.NewServer(config)
 	baseURL, err := server.Start(t.Context())
 	require.NoError(t, err)
-	defer server.Stop() //nolint:errcheck
+	defer server.Stop(context.Background()) //nolint:errcheck
 
 	// Make request
 	req, err := http.NewRequest("POST", baseURL+"/v1/chat/completions", bytes.NewReader(reqBytes))
@@ -152,7 +153,7 @@ func TestSimpleAnthropicMock(t *testing.T) {
 	server := mockllm.NewServer(config)
 	baseURL, err := server.Start(t.Context())
 	require.NoError(t, err)
-	defer server.Stop() //nolint:errcheck
+	defer server.Stop(context.Background()) //nolint:errcheck
 
 	// Make request
 	req, err := http.NewRequest("POST", baseURL+"/v1/messages", bytes.NewReader(reqBytes))
@@ -182,7 +183,7 @@ func TestHealthCheck(t *testing.T) {
 	server := mockllm.NewServer(config)
 	baseURL, err := server.Start(t.Context())
 	require.NoError(t, err)
-	defer server.Stop() //nolint:errcheck
+	defer server.Stop(context.Background()) //nolint:errcheck
 
 	resp, err := http.Get(baseURL + "/health")
 	require.NoError(t, err)


### PR DESCRIPTION
This PR fixes a race condition in the mock LLM server that causes a "use of closed network connection" error when the `Stop()` function is called.

## Problem

When the server is stopped, especially when used for e2e tests, it can panic with the following error:

```
Server error: accept tcp [::]:<port>: use of closed network connection
```

This happens because the server's main process, which is responsible for accepting new network connections, is trying to use a connection that has already been closed by the `Stop()` function. The `Start()` method launches the HTTP server in a background goroutine but the `Stop` method directly closes the underlying `net.Listener`. This causes a race condition, the listener is closed while the background server is trying to accept a new connection from it.

## Changes

Implement graceful shutdown for the http server, adding the `http.Server` instance to the `Server` struct, and using its `Serve()` and `Shutdown()` methods. The `Shutdown()` method is preferred over `Listener.Close()` because according to the go docs:

```
// Shutdown gracefully shuts down the server without interrupting any
// active connections. Shutdown works by first closing all open
// listeners, then closing all idle connections, and then waiting
// indefinitely for connections to return to idle and then shut down.
```

## Tests

All tests are passing in `server_test.go`. Previously when you run the tests:

```
=== RUN   TestSimpleOpenAIMock
Server error: accept tcp [::]:57078: use of closed network connection
--- PASS: TestSimpleOpenAIMock (0.00s)
=== RUN   TestSimpleAnthropicMock
Server error: accept tcp [::]:57081: use of closed network connection
--- PASS: TestSimpleAnthropicMock (0.00s)
=== RUN   TestHealthCheck
Server error: accept tcp [::]:57084: use of closed network connection
--- PASS: TestHealthCheck (0.00s)
PASS
ok      github.com/kagent-dev/mockllm   0.272s
```

Now:

```
❯ go test -v   
=== RUN   TestSimpleOpenAIMock
--- PASS: TestSimpleOpenAIMock (0.01s)
=== RUN   TestSimpleAnthropicMock
--- PASS: TestSimpleAnthropicMock (0.00s)
=== RUN   TestHealthCheck
--- PASS: TestHealthCheck (0.00s)
PASS
ok      github.com/kagent-dev/mockllm   0.197s
```