### PR TITLE
fix(server): fix issue with server address port

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -136,7 +136,7 @@ func TestSimpleAnthropicMock(t *testing.T) {
 	mock.Name = "test-response"
 	mock.Response = anthropicResponse
 	mock.Match = mockllm.AnthropicRequestMatch{
-		MatchType: mockllm.MatchTypeExact,
+		MatchType: mockllm.MatchTypeContains,
 		Message:   anthropicRequest.Messages[len(anthropicRequest.Messages)-1],
 	}
 	// Marshal and unmarshal the request to get it in the right format


### PR DESCRIPTION
# Description

- Revert the change to using ListenAndServe() in server, as this does not allow the ephemeral port assignment.
- Log the actual request when a mock match fails. This makes it a lot easier to get tests working.
- Add a simple form of MatchTypeContains for Anthropic mocks, rather than panic.