### PR TITLE
feat(openai): Support streaming for chat completions endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,61 @@
-## Mock LLM Server Design
+# Mock LLM Server Design
 
 This document describes the current implementation of a simple mock LLM server for end-to-end tests. It provides basic request/response mocking for OpenAI and Anthropic APIs using their official SDK types.
 
-### Goals
+## Goals
+
 - Support OpenAI Chat Completions API and Anthropic Messages API request/response schemas.
 - Simple configuration using Go structs with official SDK types.
 - Deterministic responses for testing without network calls.
 - Minimal setup for basic testing scenarios.
 
-### Current Implementation Status
-- ✅ Basic OpenAI Chat Completions API support (non-streaming)
+## Current Implementation Status
+
+- ✅ OpenAI Chat Completions API support (streaming and non-streaming)
 - ✅ Basic Anthropic Messages API support (non-streaming)
 - ✅ Simple exact and contains matching
 - ✅ In-memory configuration using Go structs
 - ✅ Tool/function calls
 - ✅ JSON configuration files
-- ❌ Streaming responses (not implemented)
 - ❌ Complex scenario engine (not implemented)
 
-### High-Level Architecture
+## High-Level Architecture
+
 The current implementation uses a simplified architecture:
+
 - **Server**: HTTP server with Gorilla mux router that handles provider-specific endpoints
 - **Provider Handlers**: Separate handlers for OpenAI and Anthropic that process requests and return mocked responses
 - **Simple Matching**: Basic matching logic that compares incoming requests against predefined mocks
 - **Direct SDK Integration**: Uses official OpenAI and Anthropic SDK types directly
 
-### Key Types
+## Key Types
+
 Current implementation uses these core types:
 
-#### Configuration
+### Configuration
+
 - `Config`: Root configuration containing arrays of OpenAI and Anthropic mocks
 - `OpenAIMock`: Maps OpenAI requests to responses using official SDK types
 - `AnthropicMock`: Maps Anthropic requests to responses using official SDK types
 
-#### Matching
+### Matching
+
 - `MatchType`: Enum for matching strategies (`exact`, `contains`)
 - `OpenAIRequestMatch`: Defines how to match OpenAI requests (match type + message)
 - `AnthropicRequestMatch`: Defines how to match Anthropic requests (match type + message)
 
-### Provider Coverage
+## Provider Coverage
 
-#### OpenAI Chat Completions
+### OpenAI Chat Completions
+
 - **Endpoint**: `POST /v1/chat/completions`
 - **Auth**: `Authorization: Bearer <token>` (presence check only)
 - **Request Type**: `openai.ChatCompletionNewParams`
-- **Response Type**: `openai.ChatCompletion`
+- **Response Type**: `openai.ChatCompletion` or `openai.ChatCompletionChunk`
 - **Matching**: Exact or contains matching on the last message in the conversation
 
-#### Anthropic Messages API
+### Anthropic Messages API
+
 - **Endpoint**: `POST /v1/messages`
 - **Auth**: `x-api-key` (presence check only)
 - **Headers**: `anthropic-version` required
@@ -139,7 +147,9 @@ config := mockllm.Config{
 ```
 
 ### Matching Algorithm
+
 Simple linear search through mocks:
+
 1. Parse incoming request into appropriate SDK type
 2. Iterate through provider-specific mocks in order
 3. For each mock, check if the match criteria are met:
@@ -149,20 +159,24 @@ Simple linear search through mocks:
 5. Return 404 if no match found
 
 ### Response Generation
+
 - All responses are non-streaming JSON
 - Uses official SDK response types directly
 - No transformation or adaptation layer
 - Standard HTTP headers (`Content-Type: application/json`)
 
 ### Files and Layout
+
 Current implementation consists of:
+
 - `server.go` — HTTP server setup, routing, and lifecycle management
 - `types.go` — Core configuration types using official SDK types
 - `openai.go` — OpenAI provider handler and matching logic
 - `anthropic.go` — Anthropic provider handler and matching logic
 - `server_test.go` — Basic integration tests
 
-### Running in Tests
+## Running in Tests
+
 ```go
 config := mockllm.Config{/* mocks */}
 server := mockllm.NewServer(config)
@@ -172,22 +186,24 @@ defer server.Stop()
 // Use baseURL for API calls in tests
 ```
 
-### SDK Dependencies
-- **OpenAI Go SDK**: `github.com/openai/openai-go`
+## SDK Dependencies
+
+- **OpenAI Go SDK**: `github.com/openai/openai-go/v3`
 - **Anthropic Go SDK**: `github.com/anthropics/anthropic-sdk-go`
 - **HTTP Router**: `github.com/gorilla/mux`
 
-### Limitations of Current Implementation
+## Limitations of Current Implementation
+
 1. **No Streaming**: Only supports non-streaming responses
 2. **Simple Matching**: Only last message matching, no complex predicates
-5. **No Multi-turn**: No stateful conversation tracking
-6. **Limited Error Handling**: Basic error responses only
-7. **No Latency Simulation**: No timing controls
+3. **No Multi-turn**: No stateful conversation tracking
+4. **Limited Error Handling**: Basic error responses only
+5. **No Latency Simulation**: No timing controls
 
-### Potential Future Enhancements (Not Implemented)
+## Potential Future Enhancements (Not Implemented)
+
 The original design document outlined more sophisticated features that could be added:
+
 - Streaming response support
 - Complex matching predicates
 - Error injection and latency simulation
-
-

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.1
 require (
 	github.com/anthropics/anthropic-sdk-go v1.13.0
 	github.com/gorilla/mux v1.8.1
-	github.com/openai/openai-go v1.12.0
+	github.com/openai/openai-go/v3 v3.15.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
-github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
+github.com/openai/openai-go/v3 v3.15.0 h1:hk99rM7YPz+M99/5B/zOQcVwFRLLMdprVGx1vaZ8XMo=
+github.com/openai/openai-go/v3 v3.15.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/openai.go
+++ b/openai.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 )
 
 // Provider handles OpenAI request/response mocking
@@ -22,9 +23,25 @@ func NewOpenAIProvider(mocks []OpenAIMock) *OpenAIProvider {
 
 // Handle processes an OpenAI chat completion request
 func (p *OpenAIProvider) Handle(w http.ResponseWriter, r *http.Request) {
+	// Parse request body to check for stream
+	// This is due to a limitation on the ChatCompletionNewParams type in the SDK
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to read body: %v", err), http.StatusBadRequest)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	// Check for stream: true in raw JSON
+	var rawMap map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &rawMap); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+
 	// Parse the incoming request into SDK type
 	var requestBody openai.ChatCompletionNewParams
-	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+	if err := json.NewDecoder(bytes.NewBuffer(bodyBytes)).Decode(&requestBody); err != nil {
 		http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
 		return
 	}
@@ -45,7 +62,16 @@ func (p *OpenAIProvider) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return the response
-	p.handleNonStreamingResponse(w, mock.Response)
+	isStream := false
+	if streamVal, ok := rawMap["stream"].(bool); ok {
+		isStream = streamVal
+	}
+
+	if isStream {
+		p.handleStreamingResponse(w, mock.Response)
+	} else {
+		p.handleNonStreamingResponse(w, mock.Response)
+	}
 }
 
 // findMatchingMock finds the first mock that matches the request
@@ -110,4 +136,115 @@ func (p *OpenAIProvider) handleNonStreamingResponse(w http.ResponseWriter, respo
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to encode response: %v", err), http.StatusInternalServerError)
 	}
+}
+
+// handleStreamingResponse sends a streaming SSE response
+func (p *OpenAIProvider) handleStreamingResponse(w http.ResponseWriter, response openai.ChatCompletion) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported by server", http.StatusInternalServerError)
+		return
+	}
+
+	// Helper to send a chunk
+	sendChunk := func(chunk openai.ChatCompletionChunk) {
+		jsonBytes, err := json.Marshal(chunk)
+		if err != nil {
+			fmt.Printf("Failed to encode chunk: %v\n", err)
+			return
+		}
+		fmt.Fprintf(w, "data: %s\n\n", jsonBytes)
+		flusher.Flush()
+	}
+
+	// 1. Initial chunk with role
+	chunk1 := openai.ChatCompletionChunk{
+		ID:      response.ID,
+		Object:  "chat.completion.chunk",
+		Created: response.Created,
+		Model:   response.Model,
+		Choices: []openai.ChatCompletionChunkChoice{
+			{
+				Index: 0,
+				Delta: openai.ChatCompletionChunkChoiceDelta{
+					Role: string(response.Choices[0].Message.Role),
+				},
+			},
+		},
+	}
+	sendChunk(chunk1)
+
+	// 2. Content chunk
+	chunk2 := openai.ChatCompletionChunk{
+		ID:      response.ID,
+		Object:  "chat.completion.chunk",
+		Created: response.Created,
+		Model:   response.Model,
+		Choices: []openai.ChatCompletionChunkChoice{
+			{
+				Index: 0,
+				Delta: openai.ChatCompletionChunkChoiceDelta{
+					Content: response.Choices[0].Message.Content,
+				},
+			},
+		},
+	}
+	sendChunk(chunk2)
+
+	// 2.5 ToolCalls chunk
+	if len(response.Choices[0].Message.ToolCalls) > 0 {
+		var toolCallDeltas []openai.ChatCompletionChunkChoiceDeltaToolCall
+		for i, tc := range response.Choices[0].Message.ToolCalls {
+			toolCallDeltas = append(toolCallDeltas, openai.ChatCompletionChunkChoiceDeltaToolCall{
+				Index: int64(i),
+				ID:    tc.ID,
+				Type:  tc.Type,
+				Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
+					Name:      tc.Function.Name,
+					Arguments: tc.Function.Arguments,
+				},
+			})
+		}
+
+		chunkTool := openai.ChatCompletionChunk{
+			ID:      response.ID,
+			Object:  "chat.completion.chunk",
+			Created: response.Created,
+			Model:   response.Model,
+			Choices: []openai.ChatCompletionChunkChoice{
+				{
+					Index: 0,
+					Delta: openai.ChatCompletionChunkChoiceDelta{
+						ToolCalls: toolCallDeltas,
+					},
+				},
+			},
+		}
+		sendChunk(chunkTool)
+	}
+
+	// 3. Finish reason chunk
+	chunk3 := openai.ChatCompletionChunk{
+		ID:      response.ID,
+		Object:  "chat.completion.chunk",
+		Created: response.Created,
+		Model:   response.Model,
+		Choices: []openai.ChatCompletionChunkChoice{
+			{
+				Index:        0,
+				Delta:        openai.ChatCompletionChunkChoiceDelta{},
+				FinishReason: response.Choices[0].FinishReason,
+			},
+		},
+	}
+	sendChunk(chunk3)
+
+	// 4. DONE
+	fmt.Fprint(w, "data: [DONE]\n\n")
+	flusher.Flush()
 }

--- a/server_test.go
+++ b/server_test.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/kagent-dev/mockllm"
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,6 +56,7 @@ func TestSimpleOpenAIMock(t *testing.T) {
 	var mock mockllm.OpenAIMock
 	mock.Name = "test-response"
 	mock.Response = openaiResponse
+
 	mock.Match = mockllm.OpenAIRequestMatch{
 		MatchType: mockllm.MatchTypeExact,
 		Message:   openaiRequest.Messages[len(openaiRequest.Messages)-1],
@@ -74,28 +76,21 @@ func TestSimpleOpenAIMock(t *testing.T) {
 	server := mockllm.NewServer(config)
 	baseURL, err := server.Start(t.Context())
 	require.NoError(t, err)
-	defer server.Stop(context.Background()) //nolint:errcheck
+	defer server.Stop(context.Background())
 
-	// Make request
-	req, err := http.NewRequest("POST", baseURL+"/v1/chat/completions", bytes.NewReader(reqBytes))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer test-key")
+	// Use Client
+	client := openai.NewClient(
+		option.WithBaseURL(baseURL+"/v1/"),
+		option.WithAPIKey("test-key"),
+	)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close() //nolint:errcheck
-
-	// Check response
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	var responseBody map[string]interface{}
-	err = json.NewDecoder(resp.Body).Decode(&responseBody)
+	resp, err := client.Chat.Completions.New(t.Context(), openaiRequest)
 	require.NoError(t, err)
 
-	assert.Equal(t, "chatcmpl-123", responseBody["id"])
-	assert.Equal(t, "chat.completion", responseBody["object"])
+	assert.Equal(t, "chatcmpl-123", resp.ID)
+	// Cast to string to avoid undefined constant issues
+	assert.Equal(t, "chat.completion", string(resp.Object))
+	assert.Equal(t, "Hello! How can I help you today?", resp.Choices[0].Message.Content)
 }
 
 func TestSimpleAnthropicMock(t *testing.T) {
@@ -197,4 +192,104 @@ func TestHealthCheck(t *testing.T) {
 
 	assert.Equal(t, "healthy", responseBody["status"])
 	assert.Equal(t, "mock-llm", responseBody["service"])
+}
+
+func TestStreamingToolCallsOpenAIMock(t *testing.T) {
+	// Request
+	openaiRequest := openai.ChatCompletionNewParams{
+		Model: "gpt-4.1-mini",
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			{
+				OfUser: &openai.ChatCompletionUserMessageParam{
+					Role: "user",
+					Content: openai.ChatCompletionUserMessageParamContentUnion{
+						OfString: openai.String("What is 2+2?"),
+					},
+				},
+			},
+		},
+	}
+
+	// Response with Tool Calls
+	openaiResponse := openai.ChatCompletion{
+		ID:      "chatcmpl-calc",
+		Object:  "chat.completion",
+		Created: 1677652288,
+		Model:   "gpt-4.1-mini",
+		Choices: []openai.ChatCompletionChoice{
+			{
+				Index: 0,
+				Message: openai.ChatCompletionMessage{
+					Role: "assistant",
+					ToolCalls: []openai.ChatCompletionMessageToolCallUnion{
+						{
+							ID:   "call_abc123",
+							Type: "function",
+							Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+								Name:      "calculate",
+								Arguments: `{"expression": "2+2"}`,
+							},
+						},
+					},
+				},
+				FinishReason: "tool_calls",
+			},
+		},
+	}
+
+	// Create mock
+	var mock mockllm.OpenAIMock
+	mock.Name = "calculate_request"
+
+	// Direct assignment as types.go uses structural typing
+	mock.Response = openaiResponse
+
+	mock.Match = mockllm.OpenAIRequestMatch{
+		MatchType: mockllm.MatchTypeContains,
+		Message:   openaiRequest.Messages[len(openaiRequest.Messages)-1],
+	}
+
+	// Marshaling setup for Match struct to be populated correctly in the config
+	reqBytes, err := json.Marshal(openaiRequest)
+	require.NoError(t, err)
+	err = json.Unmarshal(reqBytes, &mock.Match)
+	require.NoError(t, err)
+
+	config := mockllm.Config{
+		OpenAI: []mockllm.OpenAIMock{mock}, // Match Unmarshall logic issues if any?
+		// Note: OpenAI field in Config is []OpenAIMock.
+	}
+
+	server := mockllm.NewServer(config)
+	baseURL, err := server.Start(t.Context())
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
+	// Use Client
+	client := openai.NewClient(
+		option.WithBaseURL(baseURL+"/v1/"),
+		option.WithAPIKey("test-key"),
+	)
+
+	stream := client.Chat.Completions.NewStreaming(t.Context(), openaiRequest)
+
+	var receivedToolCalls []openai.ChatCompletionChunkChoiceDeltaToolCall
+
+	for stream.Next() {
+		evt := stream.Current()
+		if len(evt.Choices) > 0 {
+			if len(evt.Choices[0].Delta.ToolCalls) > 0 {
+				receivedToolCalls = append(receivedToolCalls, evt.Choices[0].Delta.ToolCalls...)
+			}
+		}
+	}
+
+	if err := stream.Err(); err != nil {
+		t.Fatalf("Stream error: %v", err)
+	}
+
+	// Expect to receive the tool call
+	require.Len(t, receivedToolCalls, 1)
+	assert.Equal(t, "calculate", receivedToolCalls[0].Function.Name)
+	assert.Equal(t, `{"expression": "2+2"}`, receivedToolCalls[0].Function.Arguments)
 }

--- a/types.go
+++ b/types.go
@@ -2,7 +2,7 @@ package mockllm
 
 import (
 	"github.com/anthropics/anthropic-sdk-go"
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/v3"
 )
 
 // Very simple mock configuration - just maps requests to responses using official SDK types


### PR DESCRIPTION
Some agent frameworks like OpenAI Agents SDK use streaming mode with `v1/chat/completions` endpoint. This PR makes it possible for the mock server to work with testing agents that use this mode.

For users, no change is required. The exact same configuration can be used and shared between streaming and non-streaming modes. The server "mocks" streaming by sending the entire content in a single chunk.

Updated OpenAI Mock related test cases to use the `open.newClient` directly for streaming and non-streaming to avoid manually sending the request. This better reflects real world usage in client libraries / agent frameworks and works more elegantly for streaming.

Also updates the Go SDK to latest v3.