### PR TITLE
[FEAT]: add header match

### DIFF
--- a/anthropic.go
+++ b/anthropic.go
@@ -41,7 +41,7 @@ func (p *AnthropicProvider) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Find a matching mock
-	mock := p.findMatchingMock(requestBody)
+	mock := p.findMatchingMock(requestBody, r.Header)
 	if mock == nil {
 		requestBodyBytes, err := json.MarshalIndent(requestBody, "", "  ")
 		if err != nil {
@@ -59,9 +59,9 @@ func (p *AnthropicProvider) Handle(w http.ResponseWriter, r *http.Request) {
 }
 
 // findMatchingMock finds the first mock that matches the request
-func (p *AnthropicProvider) findMatchingMock(request anthropic.MessageNewParams) *AnthropicMock {
+func (p *AnthropicProvider) findMatchingMock(request anthropic.MessageNewParams, headers http.Header) *AnthropicMock {
 	for _, mock := range p.mocks {
-		if p.requestsMatch(mock.Match, request) {
+		if p.requestsMatch(mock.Match, request) && headersMatch(mock.Match.Headers, headers) {
 			return &mock
 		}
 	}

--- a/headers.go
+++ b/headers.go
@@ -1,0 +1,35 @@
+package mockllm
+
+import (
+	"net/http"
+	"strings"
+)
+
+// headersMatch checks if all expected header matches are satisfied by the actual HTTP headers.
+// Returns true if expected is nil or empty (backward compatible).
+// All entries must match (AND semantics).
+func headersMatch(expected []HeaderMatch, actual http.Header) bool {
+	if len(expected) == 0 {
+		return true
+	}
+	for _, h := range expected {
+		actualValue := actual.Get(h.Name)
+		matchType := h.MatchType
+		if matchType == "" {
+			matchType = MatchTypeExact
+		}
+		switch matchType {
+		case MatchTypeExact:
+			if actualValue != h.Value {
+				return false
+			}
+		case MatchTypeContains:
+			if !strings.Contains(actualValue, h.Value) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/openai.go
+++ b/openai.go
@@ -49,7 +49,7 @@ func (p *OpenAIProvider) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Find a matching mock
-	mock := p.findMatchingMock(requestBody)
+	mock := p.findMatchingMock(requestBody, r.Header)
 	if mock == nil {
 		requestBodyBytes, err := json.MarshalIndent(requestBody, "", "  ")
 		if err != nil {
@@ -77,9 +77,9 @@ func (p *OpenAIProvider) Handle(w http.ResponseWriter, r *http.Request) {
 }
 
 // findMatchingMock finds the first mock that matches the request
-func (p *OpenAIProvider) findMatchingMock(request openai.ChatCompletionNewParams) *OpenAIMock {
+func (p *OpenAIProvider) findMatchingMock(request openai.ChatCompletionNewParams, headers http.Header) *OpenAIMock {
 	for _, mock := range p.mocks {
-		if p.requestsMatch(mock.Match, request) {
+		if p.requestsMatch(mock.Match, request) && headersMatch(mock.Match.Headers, headers) {
 			return &mock
 		}
 	}

--- a/openai_response.go
+++ b/openai_response.go
@@ -60,7 +60,7 @@ func (p *OpenAIResponseProvider) Handle(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Find a matching mock
-	mock := p.findMatchingResponseMock(requestBody)
+	mock := p.findMatchingResponseMock(requestBody, r.Header)
 	if mock == nil {
 		http.Error(w, fmt.Sprintf("No matching mock found. Request: %s",
 			string(bodyBytes)), http.StatusNotFound)
@@ -110,9 +110,9 @@ func patchResponseInputType(rawMap map[string]interface{}) {
 }
 
 // findMatchingResponseMock finds the first mock that matches the Responses API request
-func (p *OpenAIResponseProvider) findMatchingResponseMock(request responses.ResponseNewParams) *OpenAIResponseMock {
+func (p *OpenAIResponseProvider) findMatchingResponseMock(request responses.ResponseNewParams, headers http.Header) *OpenAIResponseMock {
 	for _, mock := range p.mocks {
-		if p.responseRequestsMatch(mock.Match, request) {
+		if p.responseRequestsMatch(mock.Match, request) && headersMatch(mock.Match.Headers, headers) {
 			return &mock
 		}
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -417,3 +417,158 @@ func TestOpenAICompletionAndResponseMocks(t *testing.T) {
 	assert.Equal(t, "resp_123", responseResp.ID)
 	assert.Contains(t, responseResp.OutputText(), "Kagent finds its mind")
 }
+
+func TestHeaderMatching(t *testing.T) {
+	// Create two Anthropic mocks with the same body but different required headers
+	anthropicRequest := anthropic.MessageNewParams{
+		Model:     "claude-3-5-sonnet-20240620",
+		MaxTokens: 1000,
+		Messages: []anthropic.MessageParam{
+			{
+				Role: anthropic.MessageParamRoleUser,
+				Content: []anthropic.ContentBlockParamUnion{
+					{
+						OfText: &anthropic.TextBlockParam{
+							Text: "Hello",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var responseTenantA anthropic.Message
+	loadTestData(t, "anthropic_mock.json", &responseTenantA)
+	// Override ID for tenant A
+	responseTenantA.ID = "msg_tenant_a"
+
+	var responseTenantB anthropic.Message
+	loadTestData(t, "anthropic_mock.json", &responseTenantB)
+	responseTenantB.ID = "msg_tenant_b"
+
+	mockA := newAnthropicMock(t, "tenant-a", mockllm.MatchTypeContains, anthropicRequest, responseTenantA)
+	mockA.Match.Headers = []mockllm.HeaderMatch{
+		{Name: "X-Tenant-ID", Value: "tenant-a", MatchType: mockllm.MatchTypeExact},
+	}
+
+	mockB := newAnthropicMock(t, "tenant-b", mockllm.MatchTypeContains, anthropicRequest, responseTenantB)
+	mockB.Match.Headers = []mockllm.HeaderMatch{
+		{Name: "X-Tenant-ID", Value: "tenant-b", MatchType: mockllm.MatchTypeExact},
+	}
+
+	config := mockllm.Config{
+		Anthropic: []mockllm.AnthropicMock{mockA, mockB},
+	}
+
+	baseURL, cleanup := startTestServer(t, config)
+	defer cleanup()
+
+	sendRequest := func(t *testing.T, tenantID string) *http.Response {
+		t.Helper()
+		reqBytes, err := json.Marshal(anthropicRequest)
+		require.NoError(t, err)
+
+		req, err := http.NewRequest("POST", baseURL+"/v1/messages", bytes.NewReader(reqBytes))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", "test-key")
+		req.Header.Set("anthropic-version", "2023-06-01")
+		req.Header.Set("X-Tenant-ID", tenantID)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	t.Run("exact header match selects correct mock", func(t *testing.T) {
+		resp := sendRequest(t, "tenant-a")
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]interface{}
+		err := json.NewDecoder(resp.Body).Decode(&body)
+		require.NoError(t, err)
+		assert.Equal(t, "msg_tenant_a", body["id"])
+	})
+
+	t.Run("exact header match selects other mock", func(t *testing.T) {
+		resp := sendRequest(t, "tenant-b")
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]interface{}
+		err := json.NewDecoder(resp.Body).Decode(&body)
+		require.NoError(t, err)
+		assert.Equal(t, "msg_tenant_b", body["id"])
+	})
+
+	t.Run("header mismatch returns 404", func(t *testing.T) {
+		resp := sendRequest(t, "tenant-unknown")
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}
+
+func TestHeaderContainsMatch(t *testing.T) {
+	anthropicRequest := anthropic.MessageNewParams{
+		Model:     "claude-3-5-sonnet-20240620",
+		MaxTokens: 1000,
+		Messages: []anthropic.MessageParam{
+			{
+				Role: anthropic.MessageParamRoleUser,
+				Content: []anthropic.ContentBlockParamUnion{
+					{
+						OfText: &anthropic.TextBlockParam{
+							Text: "Hello",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var anthropicResponse anthropic.Message
+	loadTestData(t, "anthropic_mock.json", &anthropicResponse)
+
+	mock := newAnthropicMock(t, "contains-header", mockllm.MatchTypeContains, anthropicRequest, anthropicResponse)
+	mock.Match.Headers = []mockllm.HeaderMatch{
+		{Name: "Authorization", Value: "Bearer", MatchType: mockllm.MatchTypeContains},
+	}
+
+	config := mockllm.Config{
+		Anthropic: []mockllm.AnthropicMock{mock},
+	}
+
+	baseURL, cleanup := startTestServer(t, config)
+	defer cleanup()
+
+	reqBytes, err := json.Marshal(anthropicRequest)
+	require.NoError(t, err)
+
+	t.Run("contains match succeeds", func(t *testing.T) {
+		req, err := http.NewRequest("POST", baseURL+"/v1/messages", bytes.NewReader(reqBytes))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", "test-key")
+		req.Header.Set("anthropic-version", "2023-06-01")
+		req.Header.Set("Authorization", "Bearer sk-test-12345")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("contains match fails when header missing", func(t *testing.T) {
+		req, err := http.NewRequest("POST", baseURL+"/v1/messages", bytes.NewReader(reqBytes))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", "test-key")
+		req.Header.Set("anthropic-version", "2023-06-01")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}

--- a/types.go
+++ b/types.go
@@ -24,9 +24,16 @@ const (
 	MatchTypeContains MatchType = "contains"
 )
 
+type HeaderMatch struct {
+	Name      string    `json:"name"`                 // Header name (case-insensitive per HTTP spec)
+	Value     string    `json:"value"`                // Value to match against
+	MatchType MatchType `json:"match_type,omitempty"` // "exact" (default) or "contains"
+}
+
 type OpenAIRequestMatch struct {
 	MatchType MatchType                              `json:"match_type"`
 	Message   openai.ChatCompletionMessageParamUnion `json:"message"`
+	Headers   []HeaderMatch                          `json:"headers,omitempty"`
 }
 
 // OpenAIMock maps an OpenAI request to a response using official SDK types
@@ -39,6 +46,7 @@ type OpenAIMock struct {
 type OpenAIResponseRequestMatch struct {
 	MatchType MatchType                             `json:"match_type"`
 	Input     responses.ResponseNewParamsInputUnion `json:"input"` // Input to match against (typically OfString)
+	Headers   []HeaderMatch                         `json:"headers,omitempty"`
 }
 
 // OpenAIResponseMock maps an OpenAI Responses API request to a response using official SDK types
@@ -51,6 +59,7 @@ type OpenAIResponseMock struct {
 type AnthropicRequestMatch struct {
 	MatchType MatchType              `json:"match_type"`
 	Message   anthropic.MessageParam `json:"message"`
+	Headers   []HeaderMatch          `json:"headers,omitempty"`
 }
 
 // AnthropicMock maps an Anthropic request to a response using official SDK types


### PR DESCRIPTION
 Summary                                                               

  - Add optional header matching to request mocking, enabling mocks to
  be differentiated by HTTP headers (e.g., tenant ID, auth tokens,
  feature flags) in addition to request body content
  - Add HeaderMatch type and Headers field to all three request match
  types (OpenAIRequestMatch, OpenAIResponseRequestMatch,
  AnthropicRequestMatch)
  - Add shared headersMatch() function with exact and contains matching,
   AND semantics, and backward compatibility (no headers = always
  matches)
  - Thread http.Header through findMatchingMock in all three providers
  (OpenAI, OpenAI Responses, Anthropic)

  Changed files

  File: types.go
  Change: New HeaderMatch struct; Headers field added to all three match

    types
  ────────────────────────────────────────
  File: headers.go
  Change: New file — shared headersMatch() function
  ────────────────────────────────────────
  File: openai.go
  Change: Pass r.Header into findMatchingMock and check header match
  ────────────────────────────────────────
  File: openai_response.go
  Change: Pass r.Header into findMatchingResponseMock and check header
    match
  ────────────────────────────────────────
  File: anthropic.go
  Change: Pass r.Header into findMatchingMock and check header match
  ────────────────────────────────────────
  File: server_test.go
  Change: New tests for exact header match, contains header match, and
    header mismatch (404)
  ────────────────────────────────────────
  File: README.md
  Change: Document header matching feature, types, JSON config, and
    updated matching algorithm

  Test plan

  - go build ./... compiles successfully
  - All existing tests pass (backward compatibility — mocks without
  headers still work)
  - TestHeaderMatching: Two mocks with same body but different
  X-Tenant-ID headers → correct mock selected; unknown tenant → 404
  - TestHeaderContainsMatch: Mock requiring Authorization header
  containing "Bearer" → matches full token; missing header → 404