### PR TITLE
Add mockllm CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ Current implementation uses these core types:
 
 ## Configuration
 
+## Running as an Executable
+
+You can run MockLLM directly from this repo:
+
+```bash
+go run ./cmd/mockllm --config ./testdata/example_config.json
+```
+
+Or build a standalone binary:
+
+```bash
+go build -o mockllm ./cmd/mockllm
+./mockllm --config ./path/to/mocks.json --listen-addr 127.0.0.1:8080
+```
+
+The process prints its base URL to stdout once the server is healthy, then keeps serving until it receives `SIGINT` or `SIGTERM`.
+
 ### Config Go Structs
 
 ```go

--- a/cmd/mockllm/main.go
+++ b/cmd/mockllm/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/kagent-dev/mockllm"
+)
+
+func main() {
+	configPath := flag.String("config", "", "Path to mockllm JSON config file")
+	listenAddr := flag.String("listen-addr", "", "Optional listen address override (for example 127.0.0.1:8080)")
+	flag.Parse()
+
+	if *configPath == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	config, err := mockllm.LoadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	if *listenAddr != "" {
+		config.ListenAddr = *listenAddr
+	}
+
+	server := mockllm.NewServer(config)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	baseURL, err := server.Start(ctx)
+	if err != nil {
+		log.Fatalf("start server: %v", err)
+	}
+
+	fmt.Println(baseURL)
+
+	<-ctx.Done()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Stop(shutdownCtx); err != nil {
+		log.Printf("stop server: %v", err)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -20,8 +21,8 @@ type Server struct {
 	openaiEmbeddingProvider *OpenAIEmbeddingProvider
 	anthropicProvider       *AnthropicProvider
 	router                  *mux.Router
-	listener               net.Listener
-	httpServer             *http.Server
+	listener                net.Listener
+	httpServer              *http.Server
 }
 
 // NewServer creates a new mock LLM server with the given config
@@ -75,6 +76,21 @@ func NewServer(config Config) *Server {
 // LoadConfigFromFile loads configuration from a JSON file
 func LoadConfigFromFile(path string, filesys fs.ReadFileFS) (Config, error) {
 	data, err := filesys.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var config Config
+	if err := json.Unmarshal(data, &config); err != nil {
+		return Config{}, fmt.Errorf("failed to parse config JSON: %w", err)
+	}
+
+	return config, nil
+}
+
+// LoadConfig loads configuration from a JSON file on the local filesystem.
+func LoadConfig(path string) (Config, error) {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to read config file: %w", err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -6,6 +6,8 @@ import (
 	"embed"
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -202,6 +204,22 @@ func TestHealthCheck(t *testing.T) {
 	assert.NotNil(t, responseBody["openai"])
 	assert.NotNil(t, responseBody["openai_response"])
 	assert.NotNil(t, responseBody["anthropic"])
+}
+
+func TestLoadConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	data, err := testdataFS.ReadFile("testdata/example_config.json")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, data, 0o600))
+
+	config, err := mockllm.LoadConfig(configPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "127.0.0.1:0", config.ListenAddr)
+	require.Len(t, config.OpenAI, 1)
+	assert.Equal(t, "hello", config.OpenAI[0].Name)
 }
 
 func TestOpenAICompletionMock(t *testing.T) {

--- a/testdata/example_config.json
+++ b/testdata/example_config.json
@@ -1,0 +1,31 @@
+{
+  "listen_addr": "127.0.0.1:0",
+  "openai": [
+    {
+      "name": "hello",
+      "match": {
+        "match_type": "contains",
+        "message": {
+          "role": "user",
+          "content": "Hello"
+        }
+      },
+      "response": {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "gpt-4o-mini",
+        "choices": [
+          {
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "content": "Hello! How can I help you today?"
+            },
+            "finish_reason": "stop"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a  executable that loads JSON config, starts the server, prints the base URL, and shuts down on SIGINT/SIGTERM
- add  for local filesystem config loading plus a test covering that path
- add a sample config file and document how to run/build the executable

## Verification
- ok  	github.com/kagent-dev/mockllm	0.021s
?   	github.com/kagent-dev/mockllm/cmd/mockllm	[no test files]
- 
